### PR TITLE
Implement single file css initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@
 
 ---
 
+### Optional Automatic Stylesheet Insertion
+
+* Optionally configure RayEditor to insert the stylesheet into the DOM so you don't have to manage it manually.
+
+---
+
 ## 🛠️ Setup Guide
 
 ### 1. Include RayEditor via CDN
@@ -125,7 +131,9 @@ document.addEventListener('DOMContentLoaded', () => {
       backgroundColor: true,
       link:true,
       table:true,
-      textAlignment:true
+      textAlignment:true,
+      initStyles: false,
+      stylesheetUrl: ""
    });
 });
 ```
@@ -159,6 +167,13 @@ E.g
   * `fileUploadUrl`: Upload endpoint for files.
   * `fileMaxSize`: Max file size in bytes.
 
+* **Custom Stylesheets & Automatic Stylesheet Insertion**
+
+  * `initStyles`: Default: false - Whether or not to automatically insert the stylesheet into the HTML DOM.
+    * Options true | false
+
+  * `stylesheetUrl`: Default: "" - If `initStyles:true` then will insert this url (relative or absolute path) into the DOM to load custom stylesheets.
+  * If left unset, defaults to the "main" branch CDN url.
 ---
 
 ## ✅ Benefits

--- a/ray-editor.js
+++ b/ray-editor.js
@@ -12,7 +12,8 @@ class RayEditor {
       this.#createToolbar();
       this.#createEditorArea();
       this.#bindEvents();
-      this.#addWatermark()
+      this.#addWatermark();
+      this.#includeCSS();
    }
    #createToolbar() {
       this.toolbar = document.createElement('div');
@@ -1169,6 +1170,23 @@ class RayEditor {
       document.querySelectorAll('.ray-editor-toolbar button').forEach(btn => {
          btn.classList.remove('active');
       });
+   }
+   #includeCSS(){
+      if(!this.options.initStyles) return;
+
+      let styleCount = document.querySelector('.ray-editor-styles')
+      if(!styleCount || styleCount.length === 0){
+      const style = document.createElement('link');
+      style.rel = 'stylesheet';
+      style.type = 'text/css';
+      style.className = 'ray-editor-styles';
+      style.href = 'https://cdn.jsdelivr.net/gh/yeole-rohan/ray-editor@main/ray-editor.css';
+      // Use the provided stylesheet URL or fallback to the CDN
+      if(this.options.stylesheetUrl && this.options.stylesheetUrl.length > 0){
+         style.href = this.options.stylesheetUrl
+      }
+      return window.document.head.appendChild(style);
+      }
    }
 }
 const buttonConfigs = {


### PR DESCRIPTION
Configurably allows the CSS stylesheet to be automatically inserted on the first RayEditor initialization.
Also provides the ability to define a relative or absolute URL for the stylesheet. 
If enabled and the stylesheetUrl field is not configured, it will default to the main-branch CDN.